### PR TITLE
Tag accounts

### DIFF
--- a/source/aws-bootstrap-kit/API.md
+++ b/source/aws-bootstrap-kit/API.md
@@ -28,6 +28,13 @@ Name|Description
 [ICrossAccountDNSDelegatorProps](#aws-bootstrap-kit-icrossaccountdnsdelegatorprops)|Properties to create delegated subzone of a zone hosted in a different account.
 
 
+**Enums**
+
+Name|Description
+----|-----------
+[AccountType](#aws-bootstrap-kit-accounttype)|*No description*
+
+
 
 ## class Account  <a id="aws-bootstrap-kit-account"></a>
 
@@ -259,6 +266,10 @@ Name | Type | Description
 -----|------|-------------
 **name** | <code>string</code> | The name of the AWS account.
 **email**? | <code>string</code> | The email associated to the AWS account.<br/>__*Optional*__
+**hostedServices**? | <code>Array<string></code> | List of your services that will be hosted in this account.<br/>__*Optional*__
+**stageName**? | <code>string</code> | The (optional) Stage name to be used in CI/CD pipeline.<br/>__*Optional*__
+**stageOrder**? | <code>number</code> | The (optional) Stage deployment order.<br/>__*Optional*__
+**type**? | <code>[AccountType](#aws-bootstrap-kit-accounttype)</code> | The account type.<br/>__*Optional*__
 
 
 
@@ -298,9 +309,13 @@ Name | Type | Description
 -----|------|-------------
 **email** | <code>string</code> | The email to use to create the AWS account.
 **name** | <code>string</code> | The name of the AWS Account.
+**hostedServices**? | <code>Array<string></code> | List of your services that will be hosted in this account.<br/>__*Optional*__
 **id**? | <code>string</code> | The AWS account Id.<br/>__*Optional*__
 **parentOrganizationalUnitId**? | <code>string</code> | The potential Organizational Unit Id the account should be placed in.<br/>__*Optional*__
 **parentOrganizationalUnitName**? | <code>string</code> | The potential Organizational Unit Name the account should be placed in.<br/>__*Optional*__
+**stageName**? | <code>string</code> | The (optional) Stage name to be used in CI/CD pipeline.<br/>__*Optional*__
+**stageOrder**? | <code>number</code> | The (optional) Stage deployment order.<br/>__*Optional*__
+**type**? | <code>[AccountType](#aws-bootstrap-kit-accounttype)</code> | The account type.<br/>__*Optional*__
 
 
 
@@ -349,5 +364,17 @@ Name | Type | Description
 **stagesAccounts** | <code>Array<[Account](#aws-bootstrap-kit-account)></code> | The stages Accounts taht will need their subzone delegation.
 **thirdPartyProviderDNSUsed**? | <code>boolean</code> | A boolean indicating if Domain name has already been registered to a third party or if you want this contruct to create it (the latter is not yet supported).<br/>__*Optional*__
 
+
+
+## enum AccountType  <a id="aws-bootstrap-kit-accounttype"></a>
+
+
+
+Name | Description
+-----|-----
+**CICD** |
+**DNS** |
+**STAGE** |
+**PLAYGROUND** |
 
 

--- a/source/aws-bootstrap-kit/lib/account-handler/index.ts
+++ b/source/aws-bootstrap-kit/lib/account-handler/index.ts
@@ -42,7 +42,7 @@ export async function onEventHandler(
       try {
         const tags: { Key: string; Value: any; }[] = [];
         Object.keys(event.ResourceProperties).forEach( propertyKey => {
-          if( propertyKey != 'ServiceToken' ) tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey].toString()});
+          if( propertyKey != 'ServiceToken' ) tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey]});
         });
         const data = await awsOrganizationsClient
         .createAccount({
@@ -97,7 +97,7 @@ export async function isCompleteHandler(
         console.log(`Add tags: type = ${event.ResourceProperties.AccountType}`);
         const tags: { Key: string; Value: any; }[] = [];
         Object.keys(event.ResourceProperties).forEach( propertyKey => {
-          if( propertyKey != 'ServiceToken' ) tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey].toString()});
+          if( propertyKey != 'ServiceToken' ) tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey]});
         });
         const tagsUpdateRequestData = await awsOrganizationsClient
         .tagResource({

--- a/source/aws-bootstrap-kit/lib/account-handler/index.ts
+++ b/source/aws-bootstrap-kit/lib/account-handler/index.ts
@@ -40,28 +40,15 @@ export async function onEventHandler(
     case "Create":
       const awsOrganizationsClient = new Organizations({region: 'us-east-1'});
       try {
+        const tags: { Key: string; Value: any; }[] = [];
+        Object.keys(event.ResourceProperties).forEach( propertyKey => {
+          if( propertyKey != 'ServiceToken' ) tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey].toString()});
+        });
         const data = await awsOrganizationsClient
         .createAccount({
           Email: event.ResourceProperties.Email,
           AccountName: event.ResourceProperties.AccountName,
-          Tags: [
-            {
-              Key: 'AccountType',
-              Value: event.ResourceProperties.AccountType
-            },
-            {
-              Key: 'StageName',
-              Value: event.ResourceProperties.StageName
-            },
-            {
-              Key: 'StageOrder',
-              Value: event.ResourceProperties.StageOrder.toString()
-            },
-            {
-              Key: 'HostedServices',
-              Value: event.ResourceProperties.HostedServices
-            }
-          ]
+          Tags: tags
         })
         .promise();
         console.log("create account: %j", data);
@@ -110,7 +97,7 @@ export async function isCompleteHandler(
         console.log(`Add tags: type = ${event.ResourceProperties.AccountType}`);
         const tags: { Key: string; Value: any; }[] = [];
         Object.keys(event.ResourceProperties).forEach( propertyKey => {
-          tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey].toString()});
+          if( propertyKey != 'ServiceToken' ) tags.push({Key: propertyKey, Value: event.ResourceProperties[propertyKey].toString()});
         });
         const tagsUpdateRequestData = await awsOrganizationsClient
         .tagResource({

--- a/source/aws-bootstrap-kit/lib/account-provider.ts
+++ b/source/aws-bootstrap-kit/lib/account-provider.ts
@@ -64,7 +64,9 @@ export class AccountProvider extends NestedStack {
 
     this.onEventHandler.addToRolePolicy(
         new iam.PolicyStatement({
-          actions: ['organizations:CreateAccount'],
+          actions: [
+            'organizations:CreateAccount'
+          ],
           resources: ['*'],
         }),
       );
@@ -81,7 +83,8 @@ export class AccountProvider extends NestedStack {
         new iam.PolicyStatement({
           actions: [
               'organizations:CreateAccount',
-              'organizations:DescribeCreateAccountStatus'
+              'organizations:DescribeCreateAccountStatus',
+              'organizations:TagResource'
             ],
           resources: ['*'],
         }),

--- a/source/aws-bootstrap-kit/lib/account.ts
+++ b/source/aws-bootstrap-kit/lib/account.ts
@@ -99,8 +99,8 @@ export class Account extends core.Construct {
           AccountName: accountProps.name,
           AccountType: accountProps.type,
           StageName: accountProps.stageName,
-          StageOrder: accountProps.stageOrder,
-          HostedServices: accountProps.hostedServices??JSON.stringify(accountProps.hostedServices)
+          StageOrder: accountProps.stageOrder?.toString(),
+          HostedServices: accountProps.hostedServices?JSON.stringify(accountProps.hostedServices):undefined
         },
       }
     );

--- a/source/aws-bootstrap-kit/lib/account.ts
+++ b/source/aws-bootstrap-kit/lib/account.ts
@@ -32,6 +32,22 @@ export interface IAccountProps {
    */
   name: string;
   /**
+   * The account type
+   */
+  type?: AccountType;
+  /**
+   * The (optional) Stage name to be used in CI/CD pipeline
+   */
+  stageName?: string;
+  /**
+   * The (optional) Stage deployment order
+   */
+  stageOrder?: number;
+  /**
+   *  List of your services that will be hosted in this account. Set it to [ALL] if you don't plan to have dedicated account for each service.
+   */
+  hostedServices?: string[];
+  /**
    * The potential Organizational Unit Id the account should be placed in 
    */
   parentOrganizationalUnitId?: string;
@@ -44,7 +60,13 @@ export interface IAccountProps {
    * The AWS account Id
    */
   id?: string;
+}
 
+export enum AccountType {
+  CICD = "CICD",
+  DNS = "DNS",
+  STAGE = "STAGE",
+  PLAYGROUND = "PLAYGROUND"
 }
 
 /**
@@ -75,6 +97,10 @@ export class Account extends core.Construct {
         properties: {
           Email: accountProps.email,
           AccountName: accountProps.name,
+          AccountType: accountProps.type,
+          StageName: accountProps.stageName,
+          StageOrder: accountProps.stageOrder,
+          HostedServices: accountProps.hostedServices??JSON.stringify(accountProps.hostedServices)
         },
       }
     );
@@ -153,7 +179,7 @@ export class Account extends core.Construct {
       );
 
       // Enabling Organizations listAccounts call for auto resolution of stages and DNS accounts Ids and Names
-      if (accountProps.name === 'CICD') {
+      if (accountProps.type === AccountType.CICD) {
         this.registerAsDelegatedAdministrator(accountId, 'ssm.amazonaws.com');
       } else {
        // Switching to another principal to workaround the max number of delegated administrators (which is set to 3 by default).

--- a/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
+++ b/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
@@ -19,7 +19,7 @@ import * as sns from '@aws-cdk/aws-sns';
 import * as subs from '@aws-cdk/aws-sns-subscriptions';
 import {Organization} from './organization';
 import {OrganizationalUnit} from './organizational-unit';
-import {Account} from './account';
+import {Account, AccountType} from './account';
 import {SecureRootUser} from './secure-root-user';
 import {OrganizationTrail} from './organization-trail';
 import {version} from '../package.json';
@@ -40,6 +40,22 @@ export interface AccountSpec {
    * The email associated to the AWS account
    */
   readonly email?: string
+  /**
+   * The account type
+   */
+  readonly type?: AccountType;
+  /**
+   * The (optional) Stage name to be used in CI/CD pipeline
+   */
+  readonly stageName?: string;
+  /**
+   * The (optional) Stage deployment order
+   */
+  readonly stageOrder?: number;
+  /**
+   *  List of your services that will be hosted in this account. Set it to [ALL] if you don't plan to have dedicated account for each service.
+   */
+  readonly hostedServices?: string[];
 }
 
 /**
@@ -129,7 +145,11 @@ export class AwsOrganizationsStack extends cdk.Stack {
       let account = new Account(this, accountSpec.name, {
         email: accountEmail,
         name: accountSpec.name,
-        parentOrganizationalUnitId: organizationalUnit.id
+        parentOrganizationalUnitId: organizationalUnit.id,
+        type: accountSpec.type,
+        stageName: accountSpec.stageName,
+        stageOrder: accountSpec.stageOrder,
+        hostedServices: accountSpec.hostedServices
       });
       // Adding an explicit dependency as CloudFormation won't infer that Organization, Organizational Units and Accounts must be created or modified sequentially
       account.node.addDependency(previousSequentialConstruct);

--- a/source/aws-bootstrap-kit/package-lock.json
+++ b/source/aws-bootstrap-kit/package-lock.json
@@ -3886,9 +3886,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.741.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.741.0.tgz",
-      "integrity": "sha512-bpk5VvlBSvKu3Lg30AxX+PHk+0TD69K3tYe6D6VeEFl/3XzuZ5RKTGCIl96isSMyYc5bBMhLS9pC9glrxT7OTw==",
+      "version": "2.771.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.771.0.tgz",
+      "integrity": "sha512-fqNGusCwkdemx3yFqvQbU1+xq/PB2wGq7EQIrrTZx/zxfXUp+7+PnrHzXtViCRghN0tylLghBfWYD4VcVcqi7g==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",

--- a/source/aws-bootstrap-kit/package.json
+++ b/source/aws-bootstrap-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-bootstrap-kit",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "repository": {
     "url": "https://github.com/awslabs/aws-bootstrap-kit",
     "type": "git"
@@ -50,7 +50,7 @@
     "@types/node": "10.17.27",
     "@types/sinon": "^9.0.5",
     "aws-cdk": "1.85.0",
-    "aws-sdk": "2.741.0",
+    "aws-sdk": "^2.771.0",
     "aws-sdk-mock": "5.1.0",
     "codecov": "^3.7.2",
     "detect-indent": "^6.0.0",

--- a/source/aws-bootstrap-kit/test/account-provider.test.ts
+++ b/source/aws-bootstrap-kit/test/account-provider.test.ts
@@ -91,6 +91,14 @@ test("on event creates account for Create requests", async () => {
     Email: "fakeAlias+fakeStage@amazon.com",
     AccountName: "Workload-fakeStage",
     Tags: [
+      { 
+        Key: "Email", 
+        Value: "fakeAlias+fakeStage@amazon.com" 
+      }, 
+      { 
+        Key: "AccountName", 
+        Value: "Workload-fakeStage" 
+      },
       {
         Key: 'AccountType',
         Value: createEvent.ResourceProperties.AccountType
@@ -223,10 +231,6 @@ test("is complete for update updates tags of the account", async () => {
   sinon.assert.calledWith(tagResourceMock, {
     ResourceId: "fakeAccountId",
     Tags: [
-      { 
-        Key: 'ServiceToken', 
-        Value: createEvent.ResourceProperties.ServiceToken
-      },
       {
         Key: 'AccountType',
         Value: createEvent.ResourceProperties.AccountType

--- a/source/aws-bootstrap-kit/test/account-provider.test.ts
+++ b/source/aws-bootstrap-kit/test/account-provider.test.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { OnEventRequest, IsCompleteRequest } from "@aws-cdk/custom-resources/lib/provider-framework/types";
 import * as AWS from "aws-sdk-mock";
 import * as sinon from "sinon";
+import { AccountType } from "../lib";
 import { isCompleteHandler, onEventHandler } from "../lib/account-handler";
 
 AWS.setSDK(require.resolve("aws-sdk"));
@@ -33,11 +34,15 @@ const createEvent: OnEventRequest = {
     ServiceToken: "fakeToken",
     Email: "fakeAlias+fakeStage@amazon.com",
     AccountName: "Workload-fakeStage",
+    AccountType: AccountType.STAGE,
+    StageName: "stage1",
+    StageOrder: 1,
+    HostedServices: '["ALL"]'
   },
 };
 
 
-const isCompleteEvent: IsCompleteRequest = {
+const isCompleteCreateEvent: IsCompleteRequest = {
   RequestType: "Create",
   ServiceToken: "fakeToken",
   ResponseURL: "fakeUrl",
@@ -50,6 +55,24 @@ const isCompleteEvent: IsCompleteRequest = {
   },
   PhysicalResourceId: "fakeRequestCreateAccountStatusId"
 }
+
+const updateEvent: OnEventRequest = { 
+  ... createEvent, 
+  RequestType: "Update",   
+  PhysicalResourceId: "fakeRequestCreateAccountStatusId" 
+}
+const isCompleteUpdateEvent: IsCompleteRequest = { 
+  ... isCompleteCreateEvent, 
+  RequestType: "Update", 
+  ResourceProperties: {
+    ServiceToken:  updateEvent.ResourceProperties.ServiceToken, 
+    AccountType: updateEvent.ResourceProperties.AccountType,
+    StageName: updateEvent.ResourceProperties.StageName,
+    StageOrder: updateEvent.ResourceProperties.StageOrder,
+    HostedServices: updateEvent.ResourceProperties.HostedServices
+  } 
+}
+
 afterEach(() => {
   AWS.restore();
 });
@@ -67,6 +90,24 @@ test("on event creates account for Create requests", async () => {
   sinon.assert.calledWith(createAccountMock, {
     Email: "fakeAlias+fakeStage@amazon.com",
     AccountName: "Workload-fakeStage",
+    Tags: [
+      {
+        Key: 'AccountType',
+        Value: createEvent.ResourceProperties.AccountType
+      },
+      {
+        Key: 'StageName',
+        Value: createEvent.ResourceProperties.StageName
+      },
+      {
+        Key: 'StageOrder',
+        Value: createEvent.ResourceProperties.StageOrder.toString()
+      },
+      {
+        Key: 'HostedServices',
+        Value: createEvent.ResourceProperties.HostedServices
+      }
+    ],
   });
 
   expect(data).toEqual({
@@ -74,20 +115,17 @@ test("on event creates account for Create requests", async () => {
   });
 });
 
-test("on event does not call createAccount for Update requests", async () => {
+test("on update event does not call createAccount for Update requests but forward properties to isCompleteHandler for tag updates", async () => {
   const createAccountMock = sinon.fake.resolves({});
 
   AWS.mock("Organizations", "createAccount", createAccountMock);
 
-  try {
-    await onEventHandler({
-      ...createEvent,
-      RequestType: "Update",
-    });
-  } catch (error) {
+  const data = await onEventHandler(updateEvent);
     sinon.assert.notCalled(createAccountMock);
-    expect(error.message).toEqual("UpdateAccount is not a supported operation");
-  }
+    expect(data).toEqual({
+      PhysicalResourceId: updateEvent.PhysicalResourceId,
+      ResourceProperties: updateEvent.ResourceProperties
+    });
 });
 
 test("is complete for create throw without requestId", async () => {
@@ -131,12 +169,12 @@ test("is complete for create returns false when account creation is in progress"
     describeCreateAccountStatusMock
   );
 
-  const data = await isCompleteHandler(isCompleteEvent);
+  const data = await isCompleteHandler(isCompleteCreateEvent);
 
   expect(data.IsComplete).toBeFalsy;
 });
 
-test("is complete for create returns false when account creation is complete", async () => {
+test("is complete for create returns true when account creation is complete", async () => {
   const describeCreateAccountStatusMock = sinon.fake.resolves({
     CreateAccountStatus: {
         State: "SUCCEEDED",
@@ -150,10 +188,63 @@ test("is complete for create returns false when account creation is complete", a
     describeCreateAccountStatusMock
   );
 
-  const data = await isCompleteHandler(isCompleteEvent);
+  const data = await isCompleteHandler(isCompleteCreateEvent);
 
   expect(data.IsComplete).toBeTruthy;
   expect(data.Data?.AccountId).toEqual("fakeAccountId");
+});
+
+test("is complete for update updates tags of the account", async () => {
+  const describeCreateAccountStatusMock = sinon.fake.resolves({
+    CreateAccountStatus: {
+        State: "SUCCEEDED",
+        AccountId: "fakeAccountId"
+    }
+  });
+  const tagResourceMock = sinon.fake.resolves({});
+
+  AWS.mock(
+    "Organizations",
+    "describeCreateAccountStatus",
+    describeCreateAccountStatusMock
+  );
+
+  AWS.mock(
+    "Organizations",
+    "tagResource",
+    tagResourceMock
+  );
+
+  const data = await isCompleteHandler(isCompleteUpdateEvent);
+
+  expect(data.IsComplete).toBeTruthy;
+  expect(data.Data?.AccountId).toEqual("fakeAccountId");
+
+  sinon.assert.calledWith(tagResourceMock, {
+    ResourceId: "fakeAccountId",
+    Tags: [
+      { 
+        Key: 'ServiceToken', 
+        Value: createEvent.ResourceProperties.ServiceToken
+      },
+      {
+        Key: 'AccountType',
+        Value: createEvent.ResourceProperties.AccountType
+      },
+      {
+        Key: 'StageName',
+        Value: createEvent.ResourceProperties.StageName
+      },
+      {
+        Key: 'StageOrder',
+        Value: createEvent.ResourceProperties.StageOrder.toString()
+      },
+      {
+        Key: 'HostedServices',
+        Value: createEvent.ResourceProperties.HostedServices
+      }
+    ],
+  });
 });
 
 test("is complete for delete  throws", async () => {
@@ -167,7 +258,7 @@ test("is complete for delete  throws", async () => {
 
   try {
     await isCompleteHandler({
-      ...isCompleteEvent,
+      ...isCompleteCreateEvent,
       RequestType: "Delete",
     });
   } catch (error) {

--- a/source/aws-bootstrap-kit/test/account-provider.test.ts
+++ b/source/aws-bootstrap-kit/test/account-provider.test.ts
@@ -36,7 +36,7 @@ const createEvent: OnEventRequest = {
     AccountName: "Workload-fakeStage",
     AccountType: AccountType.STAGE,
     StageName: "stage1",
-    StageOrder: 1,
+    StageOrder: "1",
     HostedServices: '["ALL"]'
   },
 };

--- a/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
+++ b/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
@@ -57,14 +57,14 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
                     {
                         name: 'Account1',
                         type: AccountType.PLAYGROUND,
-                        hostedServices: ['ALL']
+                        hostedServices: ['app1', 'app2']
                     },
                     {
                         name: 'Account2',
                         type: AccountType.STAGE,
                         stageOrder: 1,
                         stageName: 'stage1',
-                        hostedServices: ['ALL']
+                        hostedServices: ['app1', 'app2']
                     }
                 ]
             },
@@ -76,7 +76,7 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
                         type: AccountType.STAGE,
                         stageOrder: 2,
                         stageName: 'stage2',
-                        hostedServices: ['ALL']
+                        hostedServices: ['app1', 'app2']
                     }
                 ]
             }
@@ -138,7 +138,8 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
           ]
         },
         "AccountName": "Account1",
-        "AccountType": AccountType.PLAYGROUND
+        "AccountType": AccountType.PLAYGROUND,
+        "HostedServices": JSON.stringify(['app1', 'app2'])
     });
 
     expect(awsOrganizationsStack).toHaveResource("Custom::AccountCreation", {
@@ -157,7 +158,8 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
           "AccountName": "Account2",
           "AccountType": AccountType.STAGE,
           "StageName": "stage1",
-          "StageOrder": 1
+          "StageOrder": "1",
+          "HostedServices": JSON.stringify(['app1', 'app2'])
     });
 
     expect(awsOrganizationsStack).toHaveResource("Custom::AWS", {
@@ -196,7 +198,8 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
           "AccountName": "Account3",
           "AccountType": AccountType.STAGE,
           "StageName": "stage2",
-          "StageOrder": 2
+          "StageOrder": "2",
+          "HostedServices": JSON.stringify(['app1', 'app2'])
     });
 
 });

--- a/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
+++ b/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import "@aws-cdk/assert/jest";
-import { AwsOrganizationsStack, AwsOrganizationsStackProps } from "../lib";
+import { AccountType, AwsOrganizationsStack, AwsOrganizationsStackProps } from "../lib";
 import { Stack } from "@aws-cdk/core";
 import {version} from '../package.json';
 
@@ -26,7 +26,7 @@ const awsOrganizationsStackProps: AwsOrganizationsStackProps = {
       name: "SDLC",
       accounts: [
         {
-          name: "Account1"
+          name: "Account1",
         },
         {
           name: "Account2"
@@ -55,10 +55,16 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
                 name: 'SDLC',
                 accounts: [
                     {
-                        name: 'Account1'
+                        name: 'Account1',
+                        type: AccountType.PLAYGROUND,
+                        hostedServices: ['ALL']
                     },
                     {
-                        name: 'Account2'
+                        name: 'Account2',
+                        type: AccountType.STAGE,
+                        stageOrder: 1,
+                        stageName: 'stage1',
+                        hostedServices: ['ALL']
                     }
                 ]
             },
@@ -66,7 +72,11 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
                 name: 'Prod',
                 accounts: [
                     {
-                        name: 'Account3'
+                        name: 'Account3',
+                        type: AccountType.STAGE,
+                        stageOrder: 2,
+                        stageName: 'stage2',
+                        hostedServices: ['ALL']
                     }
                 ]
             }
@@ -116,18 +126,19 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
 
     expect(awsOrganizationsStack).toHaveResource("Custom::AccountCreation", {
         "Email": {
-            "Fn::Join": [
-              "",
-              [
-                "test+Account1-",
-                {
-                  "Ref": "AWS::AccountId"
-                },
-                "@test.com"
-              ]
+          "Fn::Join": [
+            "",
+            [
+              "test+Account1-",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              "@test.com"
             ]
-          },
-          "AccountName": "Account1"
+          ]
+        },
+        "AccountName": "Account1",
+        "AccountType": AccountType.PLAYGROUND
     });
 
     expect(awsOrganizationsStack).toHaveResource("Custom::AccountCreation", {
@@ -143,7 +154,10 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
               ]
             ]
           },
-          "AccountName": "Account2"
+          "AccountName": "Account2",
+          "AccountType": AccountType.STAGE,
+          "StageName": "stage1",
+          "StageOrder": 1
     });
 
     expect(awsOrganizationsStack).toHaveResource("Custom::AWS", {
@@ -179,7 +193,10 @@ test("when I define 1 OU with 2 accounts and 1 OU with 1 account then the stack 
               ]
             ]
           },
-          "AccountName": "Account3"
+          "AccountName": "Account3",
+          "AccountType": AccountType.STAGE,
+          "StageName": "stage2",
+          "StageOrder": 2
     });
 
 });


### PR DESCRIPTION
In order to support future use cases such as Organizations and Account import we can't keep relying on Account. name to manage the bootstrap kit logic. Therefore this PR add account tagging to replace it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Unit tests

```
---------------------------------------------------|---------|----------|---------|---------|---------------------
File                                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s   
---------------------------------------------------|---------|----------|---------|---------|---------------------
All files                                          |   95.98 |    77.97 |    97.5 |   95.95 |                     
 lib                                               |   97.61 |    75.44 |   95.65 |   97.61 |                     
  account-provider.ts                              |     100 |      100 |     100 |     100 |                     
  account.ts                                       |      96 |    83.33 |     100 |      96 | 183                 
  aws-config-recorder.ts                           |     100 |      100 |     100 |     100 |                     
  aws-organizations-stack.ts                       |      94 |    69.57 |      80 |      94 | 134,142,165         
  dns.ts                                           |   95.45 |     62.5 |     100 |   95.45 | 65                  
  index.ts                                         |     100 |      100 |     100 |     100 |                     
  organization-trail.ts                            |     100 |       50 |     100 |     100 | 145                 
  organization.ts                                  |     100 |      100 |     100 |     100 |                     
  organizational-unit.ts                           |     100 |      100 |     100 |     100 |                     
  secure-root-user.ts                              |     100 |      100 |     100 |     100 |                     
  validate-email-provider.ts                       |     100 |      100 |     100 |     100 |                     
  validate-email.ts                                |     100 |    83.33 |     100 |     100 | 46                  
 lib/account-handler                               |   94.74 |    88.46 |     100 |   94.44 |                     
  index.ts                                         |   94.74 |    88.46 |     100 |   94.44 | 57,62               
 lib/dns                                           |     100 |       50 |     100 |     100 |                     
  cross-account-dns-delegator.ts                   |     100 |      100 |     100 |     100 |                     
  cross-account-zone-delegation-record-provider.ts |     100 |       50 |     100 |     100 | 61                  
  cross-account-zone-delegation-record.ts          |     100 |       50 |     100 |     100 | 22-23               
 lib/dns/delegation-record-handler                 |   86.54 |    78.95 |     100 |   86.54 |                     
  index.ts                                         |   86.54 |    78.95 |     100 |   86.54 | 114,173-184,250-251 
 lib/validate-email-handler                        |     100 |       80 |     100 |     100 |                     
  index.ts                                         |     100 |       80 |     100 |     100 | 61-71               
---------------------------------------------------|---------|----------|---------|---------|---------------------

Test Suites: 8 passed, 8 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        25.37 s
Ran all test suites.
```

### Integ tests

See https://github.com/aws-samples/aws-bootstrap-kit-examples/pull/24

