### PR TITLE
Fix entry point for import

### DIFF
--- a/source/aws-bootstrap-kit/package.json
+++ b/source/aws-bootstrap-kit/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/awslabs/aws-bootstrap-kit",
     "type": "git"
   },
-  "main": "lib/index.ts",
+  "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "jsii": {


### PR DESCRIPTION
# Context

As of today, to use the bootstrap kit you have to import with specific entry point: 

```
import * as bootstrapKit from 'aws-bootstrap-kit/lib/index.js';
```

This PR fix it to be importable properly.﻿
