### PR TITLE
Fix Cloudtrail creation dependency

### DIFF
--- a/source/aws-bootstrap-kit/CHANGELOG.md
+++ b/source/aws-bootstrap-kit/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.3.14](https://github.com/awslabs/aws-bootstrap-kit/compare/v0.3.9...v0.3.14) (2021-08-03)
+
+
+### Bug Fixes
+
+* Creation dependencies for Cloudtrail ([0971961](https://github.com/awslabs/aws-bootstrap-kit/commit/097196174a516b3faa0a65cdf55f27df6f9b76ee))
+
 ### [0.3.13](https://github.com/awslabs/aws-bootstrap-kit/compare/v0.3.12...v0.3.13) (2021-07-15)
 
 ### [0.3.12](https://github.com/awslabs/aws-bootstrap-kit/compare/v0.3.11...v0.3.12) (2021-07-15)

--- a/source/aws-bootstrap-kit/lib/organization-trail.ts
+++ b/source/aws-bootstrap-kit/lib/organization-trail.ts
@@ -165,7 +165,7 @@ export class OrganizationTrail extends core.Construct {
             }
         ));
 
-        new AwsCustomResource(this,
+        const startLogging =  new AwsCustomResource(this,
             "OrganizationTrailStartLogging",
             {
                 onCreate: {
@@ -194,5 +194,6 @@ export class OrganizationTrail extends core.Construct {
                 )
             }
         );
+        startLogging.node.addDependency(organizationTrailCreate);
     }
 }

--- a/source/aws-bootstrap-kit/package-lock.json
+++ b/source/aws-bootstrap-kit/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-bootstrap-kit",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/source/aws-bootstrap-kit/package.json
+++ b/source/aws-bootstrap-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-bootstrap-kit",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "repository": {
     "url": "https://github.com/awslabs/aws-bootstrap-kit",
     "type": "git"


### PR DESCRIPTION
Fixing https://github.com/aws-samples/aws-bootstrap-kit-examples/issues/88


*Description of changes:* 

Previous commit removed dependency between create and start trail. Adding it back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
