### PR TITLE
feat: allow peer dependencies using newer cdk versions

### DIFF
--- a/source/aws-bootstrap-kit/package-lock.json
+++ b/source/aws-bootstrap-kit/package-lock.json
@@ -36,8 +36,8 @@
         "typescript": "~4.3.2"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.1.0",
-        "constructs": "10.0.12"
+        "aws-cdk-lib": "^2.1.0",
+        "constructs": "^10.0.12"
       }
     },
     "node_modules/@aws-cdk/assert": {

--- a/source/aws-bootstrap-kit/package.json
+++ b/source/aws-bootstrap-kit/package.json
@@ -71,7 +71,7 @@
     "constructs": "10.0.12"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.1.0",
-    "constructs": "10.0.12"
+    "aws-cdk-lib": "^2.1.0",
+    "constructs": "^10.0.12"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* 

Fixes https://github.com/awslabs/aws-bootstrap-kit/issues/76

*Description of changes:*

Allow peer deps of newer cdk version 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
