### PR TITLE
Introduce `organizationsExist`

### DIFF
--- a/source/aws-bootstrap-kit/API.md
+++ b/source/aws-bootstrap-kit/API.md
@@ -118,6 +118,7 @@ new AwsOrganizationsStack(scope: Construct, id: string, props: AwsOrganizationsS
   * **email** (<code>string</code>)  Email address of the Root account. 
   * **nestedOU** (<code>Array<[OUSpec](#aws-bootstrap-kit-ouspec)></code>)  Specification of the sub Organizational Unit. 
   * **forceEmailVerification** (<code>boolean</code>)  Enable Email Verification Process. __*Optional*__
+  * **organizationsExist** (<code>boolean</code>)  A boolean used to set if AWS Organizations is already existed. __*Optional*__
   * **rootHostedZoneDNSName** (<code>string</code>)  The main DNS domain name to manage. __*Optional*__
   * **thirdPartyProviderDNSUsed** (<code>boolean</code>)  A boolean used to decide if domain should be requested through this delpoyment or if already registered through a third party. __*Optional*__
 
@@ -340,6 +341,7 @@ Name | Type | Description
 **description**?🔹 | <code>string</code> | A description of the stack.<br/>__*Default*__: No description.
 **env**?🔹 | <code>[Environment](#aws-cdk-lib-environment)</code> | The AWS environment (account/region) where this stack will be deployed.<br/>__*Default*__: The environment of the containing `Stage` if available, otherwise create the stack will be environment-agnostic.
 **forceEmailVerification**?🔹 | <code>boolean</code> | Enable Email Verification Process.<br/>__*Optional*__
+**organizationsExist**?🔹 | <code>boolean</code> | A boolean used to set if AWS Organizations is already existed.<br/>__*Optional*__
 **rootHostedZoneDNSName**?🔹 | <code>string</code> | The main DNS domain name to manage.<br/>__*Optional*__
 **stackName**?🔹 | <code>string</code> | Name to deploy the stack with.<br/>__*Default*__: Derived from construct path.
 **synthesizer**?🔹 | <code>[IStackSynthesizer](#aws-cdk-lib-istacksynthesizer)</code> | Synthesis method to use while deploying this stack.<br/>__*Default*__: `DefaultStackSynthesizer` if the `@aws-cdk/core:newStyleStackSynthesis` feature flag is set, `LegacyStackSynthesizer` otherwise.

--- a/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
+++ b/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
@@ -94,6 +94,10 @@ export interface AwsOrganizationsStackProps extends StackProps {
   readonly nestedOU: OUSpec[],
 
   /**
+   * A boolean used to set if AWS Organizations is already existed. If it sets to `true`, instead of creating the AWS Organizations, an existing one would be loaded
+   */
+  readonly organizationsExist?: boolean,
+  /**
    * The main DNS domain name to manage
    */
   readonly rootHostedZoneDNSName?: string,
@@ -169,11 +173,11 @@ export class AwsOrganizationsStack extends Stack {
 
   constructor(scope: Construct, id: string, props: AwsOrganizationsStackProps) {
     super(scope, id, {description: `Software development Landing Zone (uksb-1r7an8o45) (version:${version})`, ...props});
-    const {email, nestedOU, forceEmailVerification = true} = props;
+    const {email, organizationsExist = false, nestedOU, forceEmailVerification = true} = props;
 
     if(nestedOU.length > 0)
     {
-      let org = new Organization(this, "Organization");
+      let org = new Organization(this, "Organization", organizationsExist);
       if(email)
       {
         this.emailPrefix = email.split('@', 2)[0];


### PR DESCRIPTION
Add a boolean to `AwsOrganizationsStackProps`. if `AWS Organizations` already exists, the toolkit won't attempt to recreate it; And details of the existing one would be loaded.

*Issue #, if available:*

*Description of changes:*
Add `organizationsExist` to `AwsOrganizationsStackProps` to take the control of  the`AWS Organizations` creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
