### PR TITLE
feat: expose dns resources and enable own rootHostedZone usage

### DIFF
--- a/source/aws-bootstrap-kit/API.md
+++ b/source/aws-bootstrap-kit/API.md
@@ -117,10 +117,19 @@ new AwsOrganizationsStack(scope: Construct, id: string, props: AwsOrganizationsS
   * **terminationProtection** (<code>boolean</code>)  Whether to enable termination protection for this stack. __*Default*__: false
   * **email** (<code>string</code>)  Email address of the Root account. 
   * **nestedOU** (<code>Array<[OUSpec](#aws-bootstrap-kit-ouspec)></code>)  Specification of the sub Organizational Unit. 
+  * **existingRootHostedZoneId** (<code>string</code>)  The (optional) existing root hosted zone id to use instead of creating one. __*Optional*__
   * **forceEmailVerification** (<code>boolean</code>)  Enable Email Verification Process. __*Optional*__
   * **rootHostedZoneDNSName** (<code>string</code>)  The main DNS domain name to manage. __*Optional*__
   * **thirdPartyProviderDNSUsed** (<code>boolean</code>)  A boolean used to decide if domain should be requested through this delpoyment or if already registered through a third party. __*Optional*__
 
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**rootDns**? | <code>[RootDns](#aws-bootstrap-kit-rootdns)</code> | __*Optional*__
 
 
 
@@ -199,6 +208,7 @@ new RootDns(scope: Construct, id: string, props: RootDnsProps)
 * **props** (<code>[RootDnsProps](#aws-bootstrap-kit-rootdnsprops)</code>)  *No description*
   * **rootHostedZoneDNSName** (<code>string</code>)  The top level domain name. 
   * **stagesAccounts** (<code>Array<[Account](#aws-bootstrap-kit-account)></code>)  The stages Accounts taht will need their subzone delegation. 
+  * **existingRootHostedZoneId** (<code>string</code>)  The (optional) existing root hosted zone id to use instead of creating one. __*Optional*__
   * **thirdPartyProviderDNSUsed** (<code>boolean</code>)  A boolean indicating if Domain name has already been registered to a third party or if you want this contruct to create it (the latter is not yet supported). __*Optional*__
 
 
@@ -209,6 +219,7 @@ new RootDns(scope: Construct, id: string, props: RootDnsProps)
 Name | Type | Description 
 -----|------|-------------
 **rootHostedZone** | <code>[aws_route53.IHostedZone](#aws-cdk-lib-aws-route53-ihostedzone)</code> | <span></span>
+**stagesHostedZones** | <code>Array<[aws_route53.HostedZone](#aws-cdk-lib-aws-route53-hostedzone)></code> | <span></span>
 
 ### Methods
 
@@ -232,16 +243,17 @@ __Returns__:
 
 
 ```ts
-createRootHostedZone(props: RootDnsProps): HostedZone
+createRootHostedZone(props: RootDnsProps): IHostedZone
 ```
 
 * **props** (<code>[RootDnsProps](#aws-bootstrap-kit-rootdnsprops)</code>)  *No description*
   * **rootHostedZoneDNSName** (<code>string</code>)  The top level domain name. 
   * **stagesAccounts** (<code>Array<[Account](#aws-bootstrap-kit-account)></code>)  The stages Accounts taht will need their subzone delegation. 
+  * **existingRootHostedZoneId** (<code>string</code>)  The (optional) existing root hosted zone id to use instead of creating one. __*Optional*__
   * **thirdPartyProviderDNSUsed** (<code>boolean</code>)  A boolean indicating if Domain name has already been registered to a third party or if you want this contruct to create it (the latter is not yet supported). __*Optional*__
 
 __Returns__:
-* <code>[aws_route53.HostedZone](#aws-cdk-lib-aws-route53-hostedzone)</code>
+* <code>[aws_route53.IHostedZone](#aws-cdk-lib-aws-route53-ihostedzone)</code>
 
 #### createStageSubZone(account, rootHostedZoneDNSName) <a id="aws-bootstrap-kit-rootdns-createstagesubzone"></a>
 
@@ -339,6 +351,7 @@ Name | Type | Description
 **analyticsReporting**?🔹 | <code>boolean</code> | Include runtime versioning information in this Stack.<br/>__*Default*__: `analyticsReporting` setting of containing `App`, or value of 'aws:cdk:version-reporting' context key
 **description**?🔹 | <code>string</code> | A description of the stack.<br/>__*Default*__: No description.
 **env**?🔹 | <code>[Environment](#aws-cdk-lib-environment)</code> | The AWS environment (account/region) where this stack will be deployed.<br/>__*Default*__: The environment of the containing `Stage` if available, otherwise create the stack will be environment-agnostic.
+**existingRootHostedZoneId**?🔹 | <code>string</code> | The (optional) existing root hosted zone id to use instead of creating one.<br/>__*Optional*__
 **forceEmailVerification**?🔹 | <code>boolean</code> | Enable Email Verification Process.<br/>__*Optional*__
 **rootHostedZoneDNSName**?🔹 | <code>string</code> | The main DNS domain name to manage.<br/>__*Optional*__
 **stackName**?🔹 | <code>string</code> | Name to deploy the stack with.<br/>__*Default*__: Derived from construct path.
@@ -414,6 +427,7 @@ Name | Type | Description
 -----|------|-------------
 **rootHostedZoneDNSName** | <code>string</code> | The top level domain name.
 **stagesAccounts** | <code>Array<[Account](#aws-bootstrap-kit-account)></code> | The stages Accounts taht will need their subzone delegation.
+**existingRootHostedZoneId**? | <code>string</code> | The (optional) existing root hosted zone id to use instead of creating one.<br/>__*Optional*__
 **thirdPartyProviderDNSUsed**? | <code>boolean</code> | A boolean indicating if Domain name has already been registered to a third party or if you want this contruct to create it (the latter is not yet supported).<br/>__*Optional*__
 
 

--- a/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
+++ b/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
@@ -99,6 +99,11 @@ export interface AwsOrganizationsStackProps extends StackProps {
   readonly rootHostedZoneDNSName?: string,
 
   /**
+   * The (optional) existing root hosted zone id to use instead of creating one
+   */
+  readonly existingRootHostedZoneId?: string,
+
+  /**
    * A boolean used to decide if domain should be requested through this delpoyment or if already registered through a third party
    */
   readonly thirdPartyProviderDNSUsed?: boolean,
@@ -202,6 +207,7 @@ export class AwsOrganizationsStack extends Stack {
       this.rootDns = new RootDns(this, 'RootDNS', {
         stagesAccounts: this.stageAccounts,
         rootHostedZoneDNSName: props.rootHostedZoneDNSName,
+        existingRootHostedZoneId: props.existingRootHostedZoneId,
         thirdPartyProviderDNSUsed: props.thirdPartyProviderDNSUsed?props.thirdPartyProviderDNSUsed:true
       });
     }

--- a/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
+++ b/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
@@ -117,6 +117,7 @@ export class AwsOrganizationsStack extends Stack {
   private readonly emailPrefix?: string;
   private readonly domain?: string;
   private readonly stageAccounts: Account[] = [];
+  public readonly rootDns?: RootDns;
 
   private createOrganizationTree(oUSpec: OUSpec, parentId: string, previousSequentialConstruct: IDependable): IDependable {
 
@@ -198,7 +199,7 @@ export class AwsOrganizationsStack extends Stack {
     }
 
     if(props.rootHostedZoneDNSName){
-      new RootDns(this, 'RootDNS', {
+      this.rootDns = new RootDns(this, 'RootDNS', {
         stagesAccounts: this.stageAccounts,
         rootHostedZoneDNSName: props.rootHostedZoneDNSName,
         thirdPartyProviderDNSUsed: props.thirdPartyProviderDNSUsed?props.thirdPartyProviderDNSUsed:true

--- a/source/aws-bootstrap-kit/lib/dns.ts
+++ b/source/aws-bootstrap-kit/lib/dns.ts
@@ -30,7 +30,8 @@ export interface RootDnsProps {
  * A class creating the main hosted zone and a role assumable by stages account to be able to set sub domain delegation
  */
 export class RootDns extends Construct {
-  rootHostedZone: route53.IHostedZone;
+  public readonly rootHostedZone: route53.IHostedZone;
+  public readonly stagesHostedZones: route53.HostedZone[] = [];
 
   constructor(scope: Construct, id: string, props: RootDnsProps) {
     super(scope, id);
@@ -42,6 +43,7 @@ export class RootDns extends Construct {
         account,
         props.rootHostedZoneDNSName
       );
+      this.stagesHostedZones.push(stageSubZone);
       this.createDNSAutoUpdateRole(account, stageSubZone);
       if (stageSubZone.hostedZoneNameServers) {
         new route53.RecordSet(

--- a/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
+++ b/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
@@ -212,6 +212,9 @@ test("should create root domain zone and stage based domain if rootHostedZoneDNS
     }
   );
 
+  expect(awsOrganizationsStack.rootDns?.rootHostedZone.zoneName).toEqual("yourdomain.com");
+  expect(awsOrganizationsStack.rootDns?.stagesHostedZones.length).toEqual(3);
+
   expect(awsOrganizationsStack).toHaveResource("AWS::Route53::HostedZone",{
     Name: "yourdomain.com."
   });

--- a/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
+++ b/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
@@ -253,6 +253,20 @@ test("should not create any zone if no domain is provided", () => {
   expect(awsOrganizationsStack).toCountResources("AWS::Route53::HostedZone",0);
 });
 
+test("should not create root zone if existing root zone id is provided", () => {
+  const awsOrganizationsStack = new AwsOrganizationsStack(
+    new Stack(),
+    "AWSOrganizationsStack",
+    {
+      ...awsOrganizationsStackProps,
+      rootHostedZoneDNSName: "yourdomain.com",
+      existingRootHostedZoneId: "existing-root-zone-id"
+    }
+  );
+
+  expect(awsOrganizationsStack).toCountResources("AWS::Route53::HostedZone", 3);
+});
+
 test("should have have email validation stack with forceEmailVerification set to true", () => {
 
   const awsOrganizationsStack = new AwsOrganizationsStack(

--- a/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
+++ b/source/aws-bootstrap-kit/test/aws-organizations-stack.test.ts
@@ -264,6 +264,12 @@ test("should not create root zone if existing root zone id is provided", () => {
     }
   );
 
+  // Check root zone not created
+  expect(awsOrganizationsStack).not.toHaveResource("AWS::Route53::HostedZone", {
+    Name: "yourdomain.com."
+  });
+
+  // Check child zones created
   expect(awsOrganizationsStack).toCountResources("AWS::Route53::HostedZone", 3);
 });
 


### PR DESCRIPTION
* Expose `rootHostedZone` and `stagesHostedZones`.
* Enable to pass its own rootHostedZoneId

#89 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
