### PR TITLE
fix: nestedOUs where raising error due to required accounts list in parent. Made accounts optional

### DIFF
--- a/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
+++ b/source/aws-bootstrap-kit/lib/aws-organizations-stack.ts
@@ -87,7 +87,7 @@ export interface OUSpec {
   /**
    * Accounts' specification inside in this Organizational Unit
    */
-  readonly accounts: AccountSpec[],
+  readonly accounts?: AccountSpec[],
 
   /**
    * Specification of sub Organizational Unit
@@ -150,7 +150,7 @@ export class AwsOrganizationsStack extends Stack {
 
     previousSequentialConstruct = organizationalUnit;
 
-    oUSpec.accounts.forEach(accountSpec => {
+    oUSpec.accounts?.forEach(accountSpec => {
       let accountEmail: string;
       if(accountSpec.email)
       {

--- a/source/aws-bootstrap-kit/test/unit/aws-organizations-stack.test.ts
+++ b/source/aws-bootstrap-kit/test/unit/aws-organizations-stack.test.ts
@@ -55,6 +55,65 @@ const awsOrganizationsStackProps: AwsOrganizationsStackProps = {
   ]
 };
 
+
+
+test("when I define nestedOUs it create the right OUs", () => {
+
+  const stack = new Stack();
+  let awsOrganizationsStackProps: AwsOrganizationsStackProps;
+  awsOrganizationsStackProps = {
+      email: "test@test.com",
+      nestedOU: [
+          {
+              name: 'SDLC',
+              nestedOU:[{
+                  name: 'App1',
+                  accounts: [
+                    {
+                        name: 'Account1',
+                        type: AccountType.PLAYGROUND,
+                        hostedServices: ['app1']
+                    }
+                ]
+              },
+              {
+                name: 'Sandbox',
+                accounts: [
+                  {
+                      name: 'App2',
+                      type: AccountType.PLAYGROUND,
+                      hostedServices: ['app2']
+                  }
+              ]
+            }]
+          },
+          {
+              name: 'Prod',
+              accounts: [
+                  {
+                      name: 'Account3',
+                      type: AccountType.STAGE,
+                      stageOrder: 3,
+                      stageName: 'stage3',
+                      hostedServices: ['app1', 'app2']
+                  }
+              ]
+          }
+      ]
+  };
+
+
+  const awsOrganizationsStack = new AwsOrganizationsStack(stack, "AWSOrganizationsStack", awsOrganizationsStackProps);
+
+  expect(awsOrganizationsStack.templateOptions.description).toMatch(`(version:${version})`);
+
+  expect(awsOrganizationsStack).toHaveResource("Custom::OrganizationCreation");
+
+  expect(awsOrganizationsStack).toCountResources("Custom::AccountCreation", 3);
+  expect(awsOrganizationsStack).toCountResources("Custom::OUCreation", 4);
+});
+
+
 test("when I define 1 OU with 3 accounts (1 existing) and 1 OU with 1 account then the stack should have 2 OU constructs and 3 account constructs", () => {
 
     const stack = new Stack();


### PR DESCRIPTION
`OuSpec`  interface requiring `accounts` to be specified, we could not create nested OUs without accounts attached to the parent. 

It has been highlighted in this issue #117 .

This PR make accounts optional enabling to create OUs without accounts in it.