### PR TITLE
Update config role

### DIFF
--- a/source/aws-bootstrap-kit/lib/aws-config-recorder.ts
+++ b/source/aws-bootstrap-kit/lib/aws-config-recorder.ts
@@ -77,7 +77,7 @@ export class ConfigRecorder extends Construct {
 
     const configRole = new iam.Role(this, 'ConfigRecorderRole', {
       assumedBy: new iam.ServicePrincipal('config.amazonaws.com'),
-      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSConfigRole')]
+      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWS_ConfigRole')]
     });
 
     new cfg.CfnConfigurationRecorder(this, 'ConfigRecorder', {


### PR DESCRIPTION
*Issue #, if available:*

`Policy arn:aws:iam::aws:policy/service-role/AWSConfigRole does not exist or is not attachable. (Service: AmazonIdentityManagement; Status Code: 404; Error Code: NoSuchEntity)`

*Description of changes:*

The managed policy AWSConfigRole has been deprecated and replaced by AWS_ConfigRole (see https://aws.amazon.com/blogs/mt/service-notice-upcoming-changes-required-for-aws-config/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
